### PR TITLE
Incomplete records

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bundle install --no-deployment
 ## Testing
 
 ```
-APP_ENV=test bundle exec rspec
+bundle exec rspec
 ```
 
 ### Updating fixtures

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bundle install --no-deployment
 ## Testing
 
 ```
-bundle exec rspec
+APP_ENV=test bundle exec rspec
 ```
 
 ### Updating fixtures
@@ -66,11 +66,11 @@ bundle exec rspec
 Fixtures are stored in `./spec/fixtures`. Those ending in `.raw` are HTTP responses captured using `curl -is` as follows:
 
 ```
-curl -is "https://platform.nypl.org/api/v0.1/items?nyplSource=sierra-nypl&bibId=10079340" -H "authorization: Bearer [**relevant access token**]" > ./spec/fixtures/platform-api-items-by-bib-10079340.raw
+curl --http1.1 -is "https://platform.nypl.org/api/v0.1/items?nyplSource=sierra-nypl&bibId=10079340" -H "authorization: Bearer [**relevant access token**]" > ./spec/fixtures/platform-api-items-by-bib-10079340.raw
 ```
 
 ```
-curl -is -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'api_key: [**scsb api key**]' -d '{"fieldName":"OwningInstitutionBibId","fieldValue": "10079340"}' 'https://[**scsb fqdn**]/searchService/search' > spec/fixtures/scsb-api-items-by-bib-id-10079340.raw
+curl --http1.1 -is -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'api_key: [**scsb api key**]' -d '{"fieldName":"OwningInstitutionBibId","fieldValue": "10079340"}' 'https://[**scsb fqdn**]/searchService/search' > spec/fixtures/scsb-api-items-by-bib-id-10079340.raw
 ```
 
 ### Representative bibs/items

--- a/spec/fixtures/scsb-api-items-by-barcode-33433121644334-dummy.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433121644334-dummy.raw
@@ -1,0 +1,8 @@
+HTTP/1.1 200 
+Date: Fri, 19 Apr 2019 19:43:47 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Set-Cookie: AWSALB=QYuX2hSbpu/oVetZKs5MHkZCkOsDO41OwM5H850aaJlZmbmMQRk62Qfc56x/m985k5r/txoD0997FvwKybJcTOFsnqGgIbTSs1cbhMeaw+4xJc20dEmjclrQ5Plk; Expires=Fri, 26 Apr 2019 19:43:47 GMT; Path=/
+
+{"searchResultRows":[{"bibId":9303702,"title":"Dummy Title","author":"Dummy Author   ","publisher":null,"publisherDate":null,"owningInstitution":"NYPL","customerCode":"NP","collectionGroupDesignation":"NA","useRestriction":"No Restrictions","barcode":"33433121644334","summaryHoldings":"","availability":"Not Available","leaderMaterialType":"Monograph","selected":false,"showItems":false,"selectAllItems":false,"searchItemResultRows":[],"itemId":15391634,"owningInstitutionBibId":"d63418","owningInstitutionHoldingsId":"d63419","owningInstitutionItemId":"d63420","requestPosition":null,"patronBarcode":null,"requestingInstitution":null,"deliveryLocation":null,"requestType":null,"requestNotes":null}],"totalPageCount":1,"totalBibRecordsCount":"1","totalItemRecordsCount":"1","totalRecordsCount":"1","showTotalCount":false,"errorMessage":null}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433121644334.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433121644334.raw
@@ -1,0 +1,8 @@
+HTTP/1.1 200 
+Date: Fri, 19 Apr 2019 19:43:55 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Set-Cookie: AWSALB=7Is1NBCuEFnKLwhw+IG5b7sTxTmYjWm9gzq00sUtU/V+tk/3XCxBedt0OjTJfOyipY1XWR40sUKAyMsFu9RMGn9+eFbUmOzYdTMYRgFrSmG/G4lyCL/2P+tDedGX; Expires=Fri, 26 Apr 2019 19:43:55 GMT; Path=/
+
+{"searchResultRows":[],"totalPageCount":0,"totalBibRecordsCount":"0","totalItemRecordsCount":"0","totalRecordsCount":"0","showTotalCount":false,"errorMessage":null}

--- a/spec/models/bib_handler_spec.rb
+++ b/spec/models/bib_handler_spec.rb
@@ -51,7 +51,7 @@ describe BibHandler  do
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-11407166.raw"))
   end
 
-  it "should load mixed bibs lookup", dev: true do
+  it "should load mixed bibs lookup" do
     expect(BibHandler.is_mixed_bib?({ 'id' => '100000885' })).to eq(true)
     expect(BibHandler.is_mixed_bib?({ 'id' => 'fladeedle' })).to eq(false)
   end

--- a/spec/models/bib_handler_spec.rb
+++ b/spec/models/bib_handler_spec.rb
@@ -51,7 +51,7 @@ describe BibHandler  do
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-11407166.raw"))
   end
 
-  it "should load mixed bibs lookup" do
+  it "should load mixed bibs lookup", dev: true do
     expect(BibHandler.is_mixed_bib?({ 'id' => '100000885' })).to eq(true)
     expect(BibHandler.is_mixed_bib?({ 'id' => 'fladeedle' })).to eq(false)
   end

--- a/spec/models/scsb_client_spec.rb
+++ b/spec/models/scsb_client_spec.rb
@@ -83,7 +83,7 @@ describe ScsbClient do
       ).to have_been_made
     end
 
-    it "should fallback on Dummy search for incomplete record", dev: true do
+    it "should fallback on Dummy search for incomplete record" do
       client = ScsbClient.new
 
       item = client.item_by_barcode('33433121644334')

--- a/spec/models/scsb_client_spec.rb
+++ b/spec/models/scsb_client_spec.rb
@@ -21,6 +21,18 @@ describe ScsbClient do
     stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
       .with(body: { fieldName: 'Barcode', fieldValue: '33433020768838', 'owningInstitutions': ['NYPL'] })
       .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433020768838.raw'))
+
+    # Stub request for Incomplete record scoped *incorrectly*:
+    stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
+      .with(body: { fieldName: 'Barcode', fieldValue: '33433121644334', 'owningInstitutions': ['NYPL'] })
+      .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433121644334.raw'))
+    # Stub request for Incomplete record scoped *correctly*:
+    stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
+      .with(body: {
+        fieldName: 'Barcode', fieldValue: '33433121644334', 'owningInstitutions': ['NYPL'],
+        deleted: false, collectionGroupDesignations: ['NA'], catalogingStatus: 'Incomplete'
+      })
+      .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433121644334-dummy.raw'))
   end
 
   describe '#items_by_bib_id' do
@@ -66,6 +78,41 @@ describe ScsbClient do
       expect(a_request(:post, "#{decoded_base_url}/searchService/search").
          with({
           body: { "fieldName" => "Barcode", "fieldValue": "33433020768838", "owningInstitutions": ['NYPL'] },
+          headers: {'Content-Type' => 'application/json', 'api_key': 'fake-key-decrypted'}
+        })
+      ).to have_been_made
+    end
+
+    it "should fallback on Dummy search for incomplete record", dev: true do
+      client = ScsbClient.new
+
+      item = client.item_by_barcode('33433121644334')
+      expect(item).to be_a(Object)
+      expect(item['bibId']).to eq(9303702)
+      expect(item['title']).to eq('Dummy Title')
+      expect(item['author'].strip).to eq('Dummy Author')
+      expect(item['owningInstitutionItemId']).to eq('d63420')
+
+      # Confirm http call was made with api key:
+      decoded_base_url = Base64.strict_decode64 ENV['SCSB_API_BASE_URL']
+      decrypted_api_key = 'fake-key-decrypted'
+
+      # Expect two SCSB requests to have been made:
+      # 1. An initial, standard query for a complete record (which fails):
+      expect(a_request(:post, "#{decoded_base_url}/searchService/search").
+         with({
+          body: { "fieldName" => "Barcode", "fieldValue": "33433121644334", "owningInstitutions": ['NYPL'] },
+          headers: {'Content-Type' => 'application/json', 'api_key': 'fake-key-decrypted'}
+        })
+      ).to have_been_made
+
+      # .. And 2) a query scoped to match Incomplete records:
+      expect(a_request(:post, "#{decoded_base_url}/searchService/search").
+         with({
+          body: {
+            "fieldName" => "Barcode", "fieldValue": "33433121644334", "owningInstitutions": ['NYPL'],
+            "deleted": false, "collectionGroupDesignations": ['NA'], "catalogingStatus": 'Incomplete'
+          },
           headers: {'Content-Type' => 'application/json', 'api_key': 'fake-key-decrypted'}
         })
       ).to have_been_made

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,9 @@ require_relative '../lib/kms_client'
 require_relative '../lib/scsb_client'
 require_relative '../lib/sierra_mod_11'
 
+ENV['LOG_LEVEL'] = 'error'
+ENV['APP_ENV'] = 'test'
+
 def load_fixture (file)
   JSON.parse File.read("./spec/fixtures/#{file}")
 end


### PR DESCRIPTION
Fixes bug where listener fails to queue metadata sync requests for
Incomplete records due to the standard SCSB API query failing for items
in that state. The new items-by-barcode lookup detects lookup failures
via the standard method and tries the query again with extra params to
enable matching against "Dummy" records.