### PR TITLE
Adds graceful handling of failed scsb item lookups

### DIFF
--- a/lib/bib_handler.rb
+++ b/lib/bib_handler.rb
@@ -57,7 +57,7 @@ class BibHandler
     holding_location_collection_type = nil
     holding_location_collection_type = mapped_location['collectionTypes'][0] if mapped_location.is_a?(Hash) && mapped_location['collectionTypes'] && mapped_location['collectionTypes'] == 1
 
-    $logger.debug "Calculating holding location collection type as #{mapped_location['collectionTypes'][0]}", { location_code: item['location']['code'], mapped_location: mapped_location }
+    $logger.debug "Calculating holding location collection type as #{holding_location_collection_type}", { location_code: item['location']['code'], mapped_location: mapped_location }
 
     holding_location_collection_type === 'Research'
   end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -13,3 +13,11 @@ class ScsbError < StandardError
     @object = object
   end
 end
+
+class ScsbNoMatchError < ScsbError
+  attr_reader :object
+
+  def initialize(object)
+    @object = object
+  end
+end

--- a/lib/scsb_client.rb
+++ b/lib/scsb_client.rb
@@ -62,7 +62,7 @@ class ScsbClient
       $logger.debug "Standard barcode search failed. #{result['searchResultRows'].empty? ? 'Did not find' : 'Found'} record via Dummy search"
     end
 
-    raise ScsbError.new(nil), "SCSB returned no match for barcode #{barcode}" if result['searchResultRows'].empty?
+    raise ScsbNoMatchError.new(nil), "SCSB returned no match for barcode #{barcode}" if result['searchResultRows'].empty?
 
     result['searchResultRows'].first
   end

--- a/spec/fixtures/item-36845773.json
+++ b/spec/fixtures/item-36845773.json
@@ -1,0 +1,225 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "15473146"
+  ],
+  "id": "36845773",
+  "nyplType": "item",
+  "updatedDate": "2019-04-25T19:30:28-04:00",
+  "createdDate": "2019-02-26T15:47:37-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "rc2ma",
+    "name": "OFFSITE - Request in Advance"
+  },
+  "status": {
+    "code": "b",
+    "display": "NEW-IN PROCESS",
+    "duedate": null
+  },
+  "barcode": "33433074008073",
+  "callNumber": "GEA (Danske Historiske Forening, Copenhagen. Historisk tidskrift)",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": "false",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "4",
+      "display": "serial, loose"
+    },
+    "62": {
+      "label": "Price",
+      "value": "0.000000",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "0",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "0",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "0",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "0",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rc2ma",
+      "display": "OFFSITE - Request in Advance"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "36845773",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2019-02-26T15:47:37Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-04-25T19:30:28Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "2",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "b",
+      "display": "NEW-IN PROCESS"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-02-26T15:47:00Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "2",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "0",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "0",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "214",
+      "display": "ReCAP (NA) - NYPL Standard"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433074008073",
+      "subfields": null
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "GEA (Danske Historiske Forening, Copenhagen. Historisk tidskrift)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "grp/vsa",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "v. 115, no. 1 (2015)",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433074008073.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433074008073.raw
@@ -1,0 +1,7 @@
+HTTP/1.1 200 
+Date: Thu, 02 May 2019 19:54:57 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+
+{"searchResultRows":[],"totalPageCount":0,"totalBibRecordsCount":"0","totalItemRecordsCount":"0","totalRecordsCount":"0","showTotalCount":false,"errorMessage":null}


### PR DESCRIPTION
Currently, failed scsb lookups don't catch the error, causing scsb item
lookup failures to halt processing (and be replayed). This patch adds a
catch to ensure failed lookups (and not other exceptions) are handled
without catastrophic failure.