### PR TITLE
Process incompletes as updates, gracefully handled failed lookups

### DIFF
--- a/lib/bib_handler.rb
+++ b/lib/bib_handler.rb
@@ -57,7 +57,7 @@ class BibHandler
     holding_location_collection_type = nil
     holding_location_collection_type = mapped_location['collectionTypes'][0] if mapped_location.is_a?(Hash) && mapped_location['collectionTypes'] && mapped_location['collectionTypes'] == 1
 
-    $logger.debug "Calculating holding location collection type as #{mapped_location['collectionTypes'][0]}", { location_code: item['location']['code'], mapped_location: mapped_location }
+    $logger.debug "Calculating holding location collection type as #{holding_location_collection_type}", { location_code: item['location']['code'], mapped_location: mapped_location }
 
     holding_location_collection_type === 'Research'
   end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -13,3 +13,11 @@ class ScsbError < StandardError
     @object = object
   end
 end
+
+class ScsbNoMatchError < ScsbError
+  attr_reader :object
+
+  def initialize(object)
+    @object = object
+  end
+end

--- a/lib/scsb_client.rb
+++ b/lib/scsb_client.rb
@@ -62,7 +62,7 @@ class ScsbClient
       $logger.debug "Standard barcode search failed. #{result['searchResultRows'].empty? ? 'Did not find' : 'Found'} record via Dummy search"
     end
 
-    raise ScsbError.new(nil), "SCSB returned no match for barcode #{barcode}" if result['searchResultRows'].empty?
+    raise ScsbNoMatchError.new(nil), "SCSB returned no match for barcode #{barcode}" if result['searchResultRows'].empty?
 
     result['searchResultRows'].first
   end

--- a/spec/fixtures/item-15496371.json
+++ b/spec/fixtures/item-15496371.json
@@ -1,0 +1,297 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "16088308"
+  ],
+  "id": "15496371",
+  "nyplType": "item",
+  "updatedDate": "2017-12-11T03:59:36-05:00",
+  "createdDate": "2009-02-10T14:25:51-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "rc2ma",
+    "name": "OFFSITE - Request in Advance"
+  },
+  "status": {
+    "code": "-",
+    "display": "AVAILABLE",
+    "duedate": null
+  },
+  "barcode": "33433068445950",
+  "callNumber": "|hSc D 05-1115",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": false,
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": 1,
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "55",
+      "display": "book, limited circ, MaRLI"
+    },
+    "62": {
+      "label": "Price",
+      "value": 0,
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": 0,
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": 0,
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": 0,
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": 0,
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": 0,
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "scff2",
+      "display": "Schomburg Center - Research & Reference"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "15496371",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2009-02-10T14:25:51Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2017-12-11T03:59:36Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "9",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "-",
+      "display": "AVAILABLE"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": 0,
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": 0,
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2014-07-17T00:24:51Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "1",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": 0,
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": 0,
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "31",
+      "display": "Schomburg"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": 0,
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": false,
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "a",
+      "marcTag": "949",
+      "ind1": " ",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "a",
+          "content": "Sc D 05-1115"
+        },
+        {
+          "tag": "c",
+          "content": "33433068445950"
+        },
+        {
+          "tag": "h",
+          "content": "1"
+        },
+        {
+          "tag": "i",
+          "content": "0"
+        },
+        {
+          "tag": "j",
+          "content": "-"
+        },
+        {
+          "tag": "k",
+          "content": "2"
+        },
+        {
+          "tag": "l",
+          "content": "$0.00"
+        },
+        {
+          "tag": "m",
+          "content": "0"
+        },
+        {
+          "tag": "n",
+          "content": "0"
+        },
+        {
+          "tag": "o",
+          "content": "0"
+        },
+        {
+          "tag": "p",
+          "content": "sg   "
+        },
+        {
+          "tag": "q",
+          "content": "-"
+        },
+        {
+          "tag": "r",
+          "content": "0"
+        },
+        {
+          "tag": "s",
+          "content": "0"
+        },
+        {
+          "tag": "t",
+          "content": "-"
+        },
+        {
+          "tag": "u",
+          "content": "-"
+        },
+        {
+          "tag": "v",
+          "content": "0"
+        },
+        {
+          "tag": "w",
+          "content": "0"
+        },
+        {
+          "tag": "x",
+          "content": ".i6432400x"
+        },
+        {
+          "tag": "y",
+          "content": "07-05-05"
+        },
+        {
+          "tag": "z",
+          "content": "09-09-05"
+        }
+      ]
+    },
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433068445950",
+      "subfields": null
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "Sc D 05-1115"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/item-36845773.json
+++ b/spec/fixtures/item-36845773.json
@@ -1,0 +1,225 @@
+{
+  "nyplSource": "sierra-nypl",
+  "bibIds": [
+    "15473146"
+  ],
+  "id": "36845773",
+  "nyplType": "item",
+  "updatedDate": "2019-04-25T19:30:28-04:00",
+  "createdDate": "2019-02-26T15:47:37-05:00",
+  "deletedDate": null,
+  "deleted": false,
+  "location": {
+    "code": "rc2ma",
+    "name": "OFFSITE - Request in Advance"
+  },
+  "status": {
+    "code": "b",
+    "display": "NEW-IN PROCESS",
+    "duedate": null
+  },
+  "barcode": "33433074008073",
+  "callNumber": "GEA (Danske Historiske Forening, Copenhagen. Historisk tidskrift)",
+  "itemType": null,
+  "fixedFields": {
+    "57": {
+      "label": "BIB HOLD",
+      "value": "false",
+      "display": null
+    },
+    "58": {
+      "label": "Copy No.",
+      "value": "1",
+      "display": null
+    },
+    "59": {
+      "label": "Item Code 1",
+      "value": "0",
+      "display": null
+    },
+    "60": {
+      "label": "Item Code 2",
+      "value": "-",
+      "display": null
+    },
+    "61": {
+      "label": "Item Type",
+      "value": "4",
+      "display": "serial, loose"
+    },
+    "62": {
+      "label": "Price",
+      "value": "0.000000",
+      "display": null
+    },
+    "64": {
+      "label": "Checkout Location",
+      "value": "0",
+      "display": null
+    },
+    "70": {
+      "label": "Checkin Location",
+      "value": "0",
+      "display": null
+    },
+    "74": {
+      "label": "Item Use 3",
+      "value": "0",
+      "display": null
+    },
+    "76": {
+      "label": "Total Checkouts",
+      "value": "0",
+      "display": null
+    },
+    "77": {
+      "label": "Total Renewals",
+      "value": "0",
+      "display": null
+    },
+    "79": {
+      "label": "Location",
+      "value": "rc2ma",
+      "display": "OFFSITE - Request in Advance"
+    },
+    "80": {
+      "label": "Record Type",
+      "value": "i",
+      "display": null
+    },
+    "81": {
+      "label": "Record Number",
+      "value": "36845773",
+      "display": null
+    },
+    "83": {
+      "label": "Created Date",
+      "value": "2019-02-26T15:47:37Z",
+      "display": null
+    },
+    "84": {
+      "label": "Updated Date",
+      "value": "2019-04-25T19:30:28Z",
+      "display": null
+    },
+    "85": {
+      "label": "No. of Revisions",
+      "value": "2",
+      "display": null
+    },
+    "86": {
+      "label": "Agency",
+      "value": "1",
+      "display": null
+    },
+    "88": {
+      "label": "Status",
+      "value": "b",
+      "display": "NEW-IN PROCESS"
+    },
+    "93": {
+      "label": "Inhouse Use",
+      "value": "0",
+      "display": null
+    },
+    "94": {
+      "label": "Copy Use",
+      "value": "0",
+      "display": null
+    },
+    "97": {
+      "label": "Item Message",
+      "value": "-",
+      "display": null
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2019-02-26T15:47:00Z",
+      "display": null
+    },
+    "108": {
+      "label": "OPAC Message",
+      "value": "2",
+      "display": null
+    },
+    "109": {
+      "label": "Year-to-Date Circ",
+      "value": "0",
+      "display": null
+    },
+    "110": {
+      "label": "Last Year Circ",
+      "value": "0",
+      "display": null
+    },
+    "127": {
+      "label": "Item Agency",
+      "value": "214",
+      "display": "ReCAP (NA) - NYPL Standard"
+    },
+    "161": {
+      "label": "VI Central",
+      "value": "0",
+      "display": null
+    },
+    "162": {
+      "label": "IR Dist Learn Same Site",
+      "value": "0",
+      "display": null
+    },
+    "264": {
+      "label": "Holdings Item Tag",
+      "value": "6",
+      "display": null
+    },
+    "265": {
+      "label": "Inherit Location",
+      "value": "false",
+      "display": null
+    },
+    "306": {
+      "label": "Sticky Status",
+      "value": " ",
+      "display": null
+    }
+  },
+  "varFields": [
+    {
+      "fieldTag": "b",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "33433074008073",
+      "subfields": null
+    },
+    {
+      "fieldTag": "c",
+      "marcTag": "852",
+      "ind1": "8",
+      "ind2": " ",
+      "content": null,
+      "subfields": [
+        {
+          "tag": "h",
+          "content": "GEA (Danske Historiske Forening, Copenhagen. Historisk tidskrift)"
+        }
+      ]
+    },
+    {
+      "fieldTag": "t",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "grp/vsa",
+      "subfields": null
+    },
+    {
+      "fieldTag": "v",
+      "marcTag": null,
+      "ind1": null,
+      "ind2": null,
+      "content": "v. 115, no. 1 (2015)",
+      "subfields": null
+    }
+  ]
+}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433068445950-dummy.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433068445950-dummy.raw
@@ -1,0 +1,7 @@
+HTTP/1.1 200 
+Date: Fri, 03 May 2019 19:53:15 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+
+{"searchResultRows":[{"bibId":9037008,"title":"Dummy Title","author":"Dummy Author   ","publisher":null,"publisherDate":null,"owningInstitution":"NYPL","customerCode":"NA","collectionGroupDesignation":"NA","useRestriction":"No Restrictions","barcode":"33433068445950","summaryHoldings":"","availability":"Not Available","leaderMaterialType":"Monograph","selected":false,"showItems":false,"selectAllItems":false,"searchItemResultRows":[],"itemId":14901917,"owningInstitutionBibId":".b160883088","owningInstitutionHoldingsId":".b160883088-57406173-d4f1-4188-b4ee-520a7b40188b","owningInstitutionItemId":"d30279","requestPosition":null,"patronBarcode":null,"requestingInstitution":null,"deliveryLocation":null,"requestType":null,"requestNotes":null}],"totalPageCount":1,"totalBibRecordsCount":"1","totalItemRecordsCount":"1","totalRecordsCount":"1","showTotalCount":false,"errorMessage":null}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433068445950.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433068445950.raw
@@ -1,0 +1,7 @@
+HTTP/1.1 200 
+Date: Fri, 03 May 2019 19:08:45 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+
+{"searchResultRows":[],"totalPageCount":0,"totalBibRecordsCount":"0","totalItemRecordsCount":"0","totalRecordsCount":"0","showTotalCount":false,"errorMessage":null}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433074008073-dummy.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433074008073-dummy.raw
@@ -1,0 +1,7 @@
+HTTP/1.1 200 
+Date: Fri, 03 May 2019 19:50:05 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+
+{"searchResultRows":[],"totalPageCount":0,"totalBibRecordsCount":"0","totalItemRecordsCount":"0","totalRecordsCount":"0","showTotalCount":false,"errorMessage":null}

--- a/spec/fixtures/scsb-api-items-by-barcode-33433074008073.raw
+++ b/spec/fixtures/scsb-api-items-by-barcode-33433074008073.raw
@@ -1,0 +1,7 @@
+HTTP/1.1 200 
+Date: Thu, 02 May 2019 19:54:57 GMT
+Content-Type: application/json;charset=UTF-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+
+{"searchResultRows":[],"totalPageCount":0,"totalBibRecordsCount":"0","totalItemRecordsCount":"0","totalRecordsCount":"0","showTotalCount":false,"errorMessage":null}

--- a/spec/models/item_handler_spec.rb
+++ b/spec/models/item_handler_spec.rb
@@ -33,6 +33,16 @@ describe ItemHandler  do
     end
   end
 
+  describe '#is_incomplete_record' do
+    it 'should identify Incomplete record' do
+      expect(ItemHandler.is_incomplete_record({ 'title' => 'Dummy Title' })).to eq(true)
+    end
+
+    it 'should identify Complete record' do
+      expect(ItemHandler.is_incomplete_record({ 'title' => 'Fair to Middling Title' })).to eq(false)
+    end
+  end
+
   describe '#item_bnum_mismatch' do
     it 'should return false for matching bib identifiers' do
       expect(ItemHandler.item_bnum_mismatch({ 'bibIds' => [ '1234' ] }, { 'owningInstitutionBibId' => '.b12348' })).to eq(false)
@@ -72,18 +82,16 @@ describe ItemHandler  do
       $notification_email = 'user@example.com'
 
       stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
+      stub_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
+        .to_return(status: 200, body: "{}" )
 
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'Barcode', fieldValue: '33433020768812', 'owningInstitutions': ['NYPL'] })
         .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433020768812.raw'))
-      stub_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
-        .to_return(status: 200, body: "{}" )
 
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'Barcode', fieldValue: '33433014464741', 'owningInstitutions': ['NYPL'] })
         .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433014464741.raw'))
-      stub_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
-        .to_return(status: 200, body: "{}" )
 
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'Barcode', fieldValue: '33433074008073', 'owningInstitutions': ['NYPL'] })
@@ -91,7 +99,18 @@ describe ItemHandler  do
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'Barcode', fieldValue: '33433074008073', 'owningInstitutions': ['NYPL'],
           'deleted': false, 'collectionGroupDesignations': ["NA"], 'catalogingStatus': "Incomplete" })
-        .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433074008073.raw'))
+        .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433074008073-dummy.raw'))
+
+      # Complete record search for 33433068445950:
+      stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
+        .with(body: { fieldName: 'Barcode', fieldValue: '33433068445950', 'owningInstitutions': ['NYPL'] })
+        .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433068445950.raw'))
+      # Incomplete record search for 33433068445950:
+      stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
+        .with(body: { fieldName: 'Barcode', fieldValue: '33433068445950', 'owningInstitutions': ['NYPL'],
+          'deleted': false, 'collectionGroupDesignations': ["NA"], 'catalogingStatus': "Incomplete"
+        })
+        .to_return(File.new('./spec/fixtures/scsb-api-items-by-barcode-33433068445950-dummy.raw'))
     end
 
     it "should handle a serial item" do
@@ -153,7 +172,7 @@ describe ItemHandler  do
     end
 
     it "should no-op an item that is not in scsb" do
-      # This is an item that doesn't exist in scsb:
+      # This is an item (barcode 33433074008073) that doesn't exist in scsb:
       item = load_fixture 'item-36845773.json'
 
       # This will trigger the ItemHandler to look up the item in scsb, which
@@ -162,6 +181,20 @@ describe ItemHandler  do
       ItemHandler.process item
 
       expect(a_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")).to have_not_been_made
+    end
+
+    it "should process an Incomplete item as an update" do
+      # barcode 33433068445950:
+      item = load_fixture 'item-15496371.json'
+
+      # This barcode will match a dummy record in SCSB search:
+      ItemHandler.process item
+
+      expect(a_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
+        .with({
+          body: { "user_email" => $notification_email, "barcodes" => [ '33433068445950' ], "source" => "bib-item-store-update"  }
+        })
+      ).to have_been_made
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require_relative '../lib/kms_client'
 require_relative '../lib/scsb_client'
 require_relative '../lib/sierra_mod_11'
 
-ENV['LOG_LEVEL'] = 'error'
+ENV['LOG_LEVEL'] ||= 'error'
 ENV['APP_ENV'] = 'test'
 
 def load_fixture (file)


### PR DESCRIPTION
Fixes incorrect treatment of Incomplete records, which were previously
being handled as transfers (due to the temporary bibid). Includes tests.

Also: Currently, failed scsb lookups don't catch the error, causing scsb item
lookup failures to halt processing (and be replayed). This patch adds a
catch to ensure failed lookups (and not other exceptions) are handled
without catastrophic failure.