### PR TITLE
Fix: skip processing items with empty barcodes

### DIFF
--- a/lib/item_handler.rb
+++ b/lib/item_handler.rb
@@ -2,14 +2,28 @@ require_relative 'sierra_mod_11'
 
 class ItemHandler
   def self.should_process? (item)
-    # Return false if item is missing required fields (i.e. deleted)
-    return false if ! item.is_a?(Hash) || ! item['location'].is_a?(Hash) || ! item['location']['code'].is_a?(String)
+    # Make sure item meets minimum format & property requirements:
+    if ! item.is_a?(Hash)
+      $logger.debug 'Refusing to process invalid item', item: item
+      return false
+    end
 
-    is_recap = ! item["location"]["code"].match(/^rc/).nil?
+    if ! item['location'].is_a?(Hash) || !item['location']['code'].is_a?(String) || item['location']['code'].empty?
+      $logger.debug 'Refusing to process item with no location', item: item
+      return false
+    end
 
-    $logger.debug 'Refusing to process item with non-recap location', { location: item["location"]["code"], itemId: item['id'] } if ! is_recap
+    if ! item['barcode'].is_a?(String) || item['barcode'].empty?
+      $logger.debug 'Refusing to process item with no barcode', item: item
+      return false
+    end
 
-    is_recap
+    if item["location"]["code"].match(/^rc/).nil?
+      $logger.debug 'Refusing to process item with non-recap location', { location: item["location"]["code"], itemId: item['id'] }
+      return false
+    end
+
+    true
   end
 
   # Given a sierraitem (Hash), returns the padded form ('b' prefix + mod11 suffix)

--- a/spec/models/item_handler_spec.rb
+++ b/spec/models/item_handler_spec.rb
@@ -8,6 +8,27 @@ describe ItemHandler  do
   end
 
   describe '#should_process?' do
+    it "should refuse to process invalid item" do
+      rc_item = "fladeedle"
+
+      expect(ItemHandler.should_process?(rc_item)).to eq(false)
+    end
+
+    it "should refuse to process an item with no location" do
+      rc_item = load_fixture 'rc-item.json'
+
+      expect(ItemHandler.should_process?(rc_item.merge({'location' => { 'code' => nil }}))).to eq(false)
+      expect(ItemHandler.should_process?(rc_item.merge({'location' => { 'code' => '' }}))).to eq(false)
+      expect(ItemHandler.should_process?(rc_item.merge({'location' => nil}))).to eq(false)
+    end
+
+    it "should refuse to process an item with no barcode" do
+      rc_item = load_fixture 'rc-item.json'
+
+      expect(ItemHandler.should_process?(rc_item.merge({'barcode' => nil}))).to eq(false)
+      expect(ItemHandler.should_process?(rc_item.merge({'barcode' => ''}))).to eq(false)
+    end
+
     it "should consider an item with a rc location valid for processing" do
       rc_item = load_fixture 'rc-item.json'
 


### PR DESCRIPTION
Addresses poor handling of bad item data generally. Better checks for
valid item locations. New check for non-empty barcode. Empty barcodes
sometimes appear in the Item stream for some reason. Querying an empty
barcode against SCSB api returns multiple results for some reason.
Chaos, etc. This fix causes processing to halt immediately for an item
if barcode empty.