### PR TITLE
Fix misleading request stub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language:
 - ruby
+before_install:
+- gem update --system
+- gem install bundler
 install:
 - bundle install
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/
@@ -39,7 +39,7 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://qa-platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/
@@ -63,7 +63,7 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/

--- a/spec/models/platform_api_client_spec.rb
+++ b/spec/models/platform_api_client_spec.rb
@@ -17,7 +17,7 @@ describe PlatformApiClient do
     $logger = NyplLogFormatter.new(STDOUT, level: ENV['LOG_LEVEL'] || 'info')
 
     stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/b12082323").to_return(status: 200, body: File.read('./spec/fixtures/bib.json'))
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/12082323").to_return(status: 200, body: File.read('./spec/fixtures/bib.json'))
   end
 
   it "should authenticate when calling with :authenticate => true" do
@@ -27,7 +27,7 @@ describe PlatformApiClient do
     expect(client.instance_variable_get(:@access_token)).to be_nil
 
     # Call an endpoint with authentication:
-    expect(client.get('bibs/sierra-nypl/b12082323', authenicate: true)).to be_a(Object)
+    expect(client.get('bibs/sierra-nypl/12082323', authenicate: true)).to be_a(Object)
 
     # Verify access_token retrieved:
     expect(client.instance_variable_get(:@access_token)).to be_a(String)


### PR DESCRIPTION
Primarily: Corrects a misleading stub, which wrongly used a 'b' in a bib id (`bibs/sierra-nypl/b12082323`). It *worked* because the typo was repeated in the test, but it's misleading.

Secondarily:
 - Updates lambda timeout from 10s to 60s to match live config.
 - Adds explicit `gem install bundler` to `.travis.yml` to ensure a global `bundler` is installed because [for ruby 2.5 sometimes that fails](https://github.com/rbenv/rbenv/issues/1138)