### PR TITLE
Update UAT URL to latest for qa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language:
 - ruby
+before_install:
+- gem update --system
+- gem install bundler
 install:
 - bundle install
 cache:
@@ -16,13 +19,13 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://dev-platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/
   - NYPL_OAUTH_ID=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIEwfwYJKoZIhvcNAQcGoHIwcAIBADBrBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDGyPfKIRQSicYi2GxgIBEIA++LFd13mvgmjDLIZSEGY7JlIXcn+LwWVdQvPv06cxIjCgzqTDGFI0BJBvRxEkBXY0MjHd5bopsMzi/xGYgtw=
   - NYPL_OAUTH_SECRET=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwfmXJJ7APHHkDaZ/sCARCAQ1khePr8PwO+gRNxElCwlS6Y27YB4HNJmVbzNVcFBpEyXacpIdhVer3mAw+psm5e+6K4Twf9JC7GBIPLxGKr8AQRbpY=
-  - SCSB_API_BASE_URL=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIAwfgYJKoZIhvcNAQcGoHEwbwIBADBqBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDC76YFNmHCel71yszwIBEIA9rRyZEpeLBxMs8wjvsVRuWXU2RoEvtYbg4GkbaRMK5c6DOKPReBD6ehzyxLQriwMBa5U30qXRDaKmSR7OIw==
+  - SCSB_API_BASE_URL=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAH8wfQYJKoZIhvcNAQcGoHAwbgIBADBpBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDGPx1k56KvjAY862gAIBEIA8jxlvKk9UEscHisjP351iadHtpRrOwcl5vCPsxt8mQQl8BlJIcAcXow0XmExbF2bIgm9FUPH+2qemCIBB
   - SCSB_API_KEY=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGMwYQYJKoZIhvcNAQcGoFQwUgIBADBNBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDBGj6VVDSTYYcLzAdgIBEIAgOtoxPpUgkHHgc3eipZzyfMEUwYHIt7VvXy9Y5GRkVik=
   - LOG_LEVEL=debug
   skip_cleanup: true
@@ -39,7 +42,7 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://qa-platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/
@@ -63,7 +66,7 @@ deploy:
   runtime: ruby2.5
   module_name: app
   handler_name: handle_event
-  timeout: 10
+  timeout: 60
   environment_variables:
   - PLATFORM_API_BASE_URL=https://platform.nypl.org/api/v0.1/
   - NYPL_OAUTH_URL=https://isso.nypl.org/


### PR DESCRIPTION
This updates QA deploy hook with the new URL for UAT (test ReCAP).

Also increases lambda timeouts to match deployed settings.