### PR TITLE
Update items-by-bib query due to production performance issue

### DIFF
--- a/lib/bib_handler.rb
+++ b/lib/bib_handler.rb
@@ -3,79 +3,20 @@ require_relative 'nypl_core'
 class BibHandler
   @@mixed_bib_ids = nil
 
-  # Get the first item associated with the given bib id from ItemService
-  def self.first_item_by_bib_id (id) 
-    # Note that we'd like to pass `&limit=1` here, but ItemService seems to
-    # have a bug ( https://github.com/NYPL-discovery/itemservice/issues/5 )
-    items = $platform_api.get "bibs/sierra-nypl/#{id}/items"
-    if (items.nil? || items.empty? || items['data'].nil? || !items['data'].is_a?(Array))
-      $logger.error "Bad response from ItemService querying for first item by bib id #{id}", items
-      nil
-    else
-      items['data'][0]
-    end
-  end
+  def self.has_rl_tag? (bib)
+    p bib
+    return false unless bib['varFields'].is_a?(Array)
 
-  # Determine if the first item of the given bib is a Research item
-  def self.first_item_is_research? (bib)
-    $logger.debug "Fetching first item for bib #{bib['id']}"
+    var_field_910 = bib['varFields'].find { |var| var['marcTag'] == '910' }
+    return false unless var_field_910
+  
+    subfield_a = var_field_910['subfields'].find { |sub| sub['tag'] == 'a' }
+    return false unless subfield_a
 
-    first_item = first_item_by_bib_id bib['id']
+    content = subfield_a['content']
+    $logger.debug "910|a for #{bib['id']} is #{content}"
 
-    # If no items matched for the bnum, return false
-    return false if first_item.nil?
-
-    $logger.debug "Got first item for bib #{bib['id']}", first_item
-
-    # Check the two relevant scenarios that obligate the item to be Research:
-    item_has_research_item_type?(first_item) || item_has_research_location?(first_item)
-  end
-
-  # Return true if item's "catalog item type" identifies it as Research
-  # Based on https://github.com/NYPL-discovery/discovery-store-poster/blob/33baaad06dd73f45089bb780dbb4afd5a13e2204/lib/models/item-sierra-record.js#L40-L47
-  def self.item_has_research_item_type? (item)
-    raise "Error parsing item: no fixedFields" if item['fixedFields'].nil?
-    raise "Error parsing item: invalid fixedFields" if ! item['fixedFields'].is_a?(Hash)
-
-    item_type = item['fixedFields'].values.select { |field| field['label'] == 'Item Type' }.pop
-    item_type = item_type['value'] if ! item_type.nil? && item_type.is_a?(Hash) && item_type['value'].is_a?(String)
-
-    mapped_item_type = $nypl_core.by_catalog_item_type[item_type]
-
-    mapped_item_type_is_research = mapped_item_type.is_a?(Hash) && mapped_item_type['collectionType'].is_a?(Array) && mapped_item_type['collectionType'].include?('Research')
-
-    $logger.debug "Calculating item_has_research_item_type=#{mapped_item_type_is_research}", { item_type: item_type, mapped_item_type: mapped_item_type }
-
-    mapped_item_type_is_research
-  end
-
-  # Return true if item's location has *only* "Research" materials
-  # Based on https://github.com/NYPL-discovery/discovery-store-poster/blob/33baaad06dd73f45089bb780dbb4afd5a13e2204/lib/models/item-sierra-record.js#L30-L38
-  def self.item_has_research_location? (item)
-    # Determine collection type of first item:
-    mapped_location = $nypl_core.by_sierra_location[item['location']['code']]
-    holding_location_collection_type = nil
-    holding_location_collection_type = mapped_location['collectionTypes'][0] if mapped_location.is_a?(Hash) && mapped_location['collectionTypes'] && mapped_location['collectionTypes'] == 1
-
-    $logger.debug "Calculating holding location collection type as #{holding_location_collection_type}", { location_code: item['location']['code'], mapped_location: mapped_location }
-
-    holding_location_collection_type === 'Research'
-  end
-
-  # Return true if given bib has been identified as a "mixed bib"
-  def self.is_mixed_bib? (bib)
-    if @@mixed_bib_ids.nil?
-      @@mixed_bib_ids = File.read('data/mixed-bibs.csv')
-        .split("\n")
-        .map { |bnum| bnum.strip.sub(/^b/, '') }
-
-      $logger.debug "Loaded #{@@mixed_bib_ids.size} mixed bib ids"
-    end
-
-    is_mixed_bib = @@mixed_bib_ids.include? bib['id']
-    $logger.debug "Determined is_mixed_bib=#{is_mixed_bib} for #{bib['id']}"
-
-    is_mixed_bib
+    content == 'RL'
   end
 
   # Returns true if we should process this bib - either because:
@@ -84,13 +25,10 @@ class BibHandler
   #  2. its first item has a research Item Type or location, meaning it *may*
   #     be in recap
   def self.should_process? (bib)
-    is_mixed = is_mixed_bib?(bib)
-    return true if is_mixed
+    has_rl_tag = has_rl_tag?(bib)
+    return true if has_rl_tag
 
-    first_item_research = first_item_is_research?(bib)
-    return true if first_item_research
-
-    $logger.info "Refusing to process bib #{bib['id']} because is_mixed=#{is_mixed}, first_item_research=#{first_item_research}"
+    $logger.info "Refusing to process bib #{bib['id']} because has_rl_tag=#{has_rl_tag}"
     false
   end
 

--- a/lib/bib_handler.rb
+++ b/lib/bib_handler.rb
@@ -3,8 +3,8 @@ require_relative 'nypl_core'
 class BibHandler
   @@mixed_bib_ids = nil
 
+  # Returns true if the bib has a 910|a = 'RL', false otherwise
   def self.has_rl_tag? (bib)
-    p bib
     return false unless bib['varFields'].is_a?(Array)
 
     var_field_910 = bib['varFields'].find { |var| var['marcTag'] == '910' }

--- a/lib/bib_handler.rb
+++ b/lib/bib_handler.rb
@@ -7,7 +7,7 @@ class BibHandler
   def self.first_item_by_bib_id (id) 
     # Note that we'd like to pass `&limit=1` here, but ItemService seems to
     # have a bug ( https://github.com/NYPL-discovery/itemservice/issues/5 )
-    items = $platform_api.get "items?nyplSource=sierra-nypl&bibId=#{id}"
+    items = $platform_api.get "bibs/sierra-nypl/#{id}/items"
     if (items.nil? || items.empty? || items['data'].nil? || !items['data'].is_a?(Array))
       $logger.error "Bad response from ItemService querying for first item by bib id #{id}", items
       nil

--- a/spec/models/bib_handler_spec.rb
+++ b/spec/models/bib_handler_spec.rb
@@ -3,6 +3,7 @@ require 'webmock/rspec'
 require 'aws-sdk-kms'
 
 describe BibHandler  do
+  varfield_910_rl = { 'marcTag' => '910', 'subfields' => [ { 'tag' => 'a', 'content' => 'RL' } ] }
 
   before(:each) do
     $logger = NyplLogFormatter.new(STDOUT, level: ENV['LOG_LEVEL'] || 'info')
@@ -51,57 +52,21 @@ describe BibHandler  do
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-11407166.raw"))
   end
 
-  it "should load mixed bibs lookup" do
-    expect(BibHandler.is_mixed_bib?({ 'id' => '100000885' })).to eq(true)
-    expect(BibHandler.is_mixed_bib?({ 'id' => 'fladeedle' })).to eq(false)
-  end
-
-  it "should query first item by bib id" do
-    first_item = BibHandler.first_item_by_bib_id('10079340')
-    expect(first_item).to be_a(Object)
-    expect(first_item['id']).to eq('11907245')
-  end
-
-  it "should identify item with research Item Type as research" do
-    item_type = "3"
-    is_research = BibHandler.item_has_research_item_type?({ "fixedFields" => { "0" => { "label" => "Item Type", "value" => item_type } } })
-    expect(is_research).to eq(true)
-  end
-
-  it "should identify item with non-research Item Type as non-research" do
-    item_type = "138"
-    is_research = BibHandler.item_has_research_item_type?({ "fixedFields" => { "0" => { "label" => "Item Type", "value" => item_type } } })
-    expect(is_research).to eq(false)
-  end
-
-  it "should identify item with non-research location as non-research" do
-    is_research = BibHandler.item_has_research_item_type?({ "location" => { "code" => "hfa0f" }, "fixedFields" => {} })
-    expect(is_research).to eq(false)
-  end
-
-  it "should identify item with non-research location as non-research" do
-    is_research = BibHandler.item_has_research_item_type?({ "location" => { "code" => "rc2ma" }, "fixedFields" => {} })
-    expect(is_research).to eq(false)
-  end
-
-  it "should identify first item as research" do
-    is_research = BibHandler.first_item_is_research?({ "id" => "10079340" })
-    expect(is_research).to eq(true)
-  end
-
-  it "should identify first item as non-research" do
-    # this item has non-research Item Type:
-    is_research = BibHandler.first_item_is_research?({ "id" => "20918822" })
-    expect(is_research).to eq(false)
-  end
-
   describe '#should_process?' do
-    it "should consider a bib valid for processing if it is mixed" do
-      expect(BibHandler.should_process?({ 'id' => '100000885' })).to eq(true)
+    it "should consider a bib valid for processing if it has a 910|a=RL" do
+      expect(BibHandler.should_process?({ 'id' => '10079340', 'varFields' => [ varfield_910_rl ] })).to eq(true)
     end
 
-    it "should consider a bib valid for processing if its first item is research" do
-      expect(BibHandler.should_process?({ 'id' => '10079340' })).to eq(true)
+    it "should consider a bib NOT valid for processing if has anything but 910|a=RL" do
+      expect(BibHandler.should_process?({ 'id' => '10079340', 'varFields' => [ 
+        { 'marcTag' => '910', 'subfields' => [ { 'tag' => 'a', 'content' => 'BL' } ] }
+      ]})).to eq(false)
+
+      expect(BibHandler.should_process?({ 'id' => '10079340', 'varFields' => [ 
+        { 'marcTag' => '910', 'subfields' => [ { 'tag' => 'a', 'content' => 'RLOTF' } ] }
+      ]})).to eq(false)
+
+      expect(BibHandler.should_process?({ 'id' => '10079340', 'varFields' => [] })).to eq(false)
     end
 
     it "should not consider a bib valid for processing if it's not mixed and its first item is non-research" do
@@ -122,15 +87,13 @@ describe BibHandler  do
 
   describe "#process" do
     before(:each) do
-      stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/19822713/items")
-        .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-19822713.raw"))
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'OwningInstitutionBibId', fieldValue: '.b198227139', 'owningInstitutions': ['NYPL'] })
         .to_return(File.new('./spec/fixtures/scsb-api-items-by-bib-id-b198227139.raw'))
     end
 
     it "should submit all item barcodes for a valid bib to the sync endpoint" do
-      BibHandler.process({ 'id' => '19822713' })
+      BibHandler.process({ 'id' => '19822713', 'varFields' => [ varfield_910_rl ] })
 
       expect(a_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
         .with({
@@ -142,7 +105,7 @@ describe BibHandler  do
   end
 
   it "should submit all item barcodes for a serial bib to the sync endpoint" do
-    BibHandler.process({ 'id' => '10079340' })
+    BibHandler.process({ 'id' => '10079340', 'varFields' => [ varfield_910_rl ]  })
 
     # This is a serial with 4 items in scsb
     expect(a_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
@@ -153,7 +116,7 @@ describe BibHandler  do
   end
 
   it "should not submit anything if bib determined to be possibly in recap but SCSB returns no items" do
-    BibHandler.process({ 'id' => '11407166' })
+    BibHandler.process({ 'id' => '11407166', 'varFields' => [ varfield_910_rl ]  })
 
     expect(a_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
       .with({

--- a/spec/models/bib_handler_spec.rb
+++ b/spec/models/bib_handler_spec.rb
@@ -32,14 +32,6 @@ describe BibHandler  do
 
     stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
 
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/10079340/items")
-      .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-10079340.raw"))
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/20918822/items")
-      .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-20918822.raw"))
-    stub_request(:get, "https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_catalog_item_type.json")
-      .to_return(status: 200, body: File.read('./spec/fixtures/by_catalog_item_type.json')) 
-    stub_request(:get, "https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_sierra_location.json")
-      .to_return(status: 200, body: File.read('./spec/fixtures/by_sierra_location.json')) 
     stub_request(:post, "#{ENV['PLATFORM_API_BASE_URL']}recap/sync-item-metadata-to-scsb")
       .to_return(status: 200, body: "{}" )
     stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
@@ -48,8 +40,6 @@ describe BibHandler  do
     stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
       .with(body: { fieldName: 'OwningInstitutionBibId', fieldValue: '.b114071664', 'owningInstitutions': ['NYPL'] })
       .to_return(File.new('./spec/fixtures/scsb-api-items-by-bib-id-11407166.raw'))
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/11407166/items")
-      .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-11407166.raw"))
   end
 
   describe '#should_process?' do
@@ -74,11 +64,6 @@ describe BibHandler  do
     end
 
     describe "#should_process?" do
-      before(:each) do
-        stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/fakebibid/items")
-          .to_return(status: 404, body: '{"statusCode":404,"type":"exception","message":"No records found","error":[],"debugInfo":[]}')
-      end
-
       it "should quietly fail to process any bib for which there are no items" do
         expect(BibHandler.should_process?({ 'id' => 'fakebibid' })).to eq(false)
       end

--- a/spec/models/bib_handler_spec.rb
+++ b/spec/models/bib_handler_spec.rb
@@ -31,9 +31,9 @@ describe BibHandler  do
 
     stub_request(:post, "#{ENV['NYPL_OAUTH_URL']}oauth/token").to_return(status: 200, body: '{ "access_token": "fake-access-token" }')
 
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items?nyplSource=sierra-nypl&bibId=10079340")
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/10079340/items")
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-10079340.raw"))
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items?nyplSource=sierra-nypl&bibId=20918822")
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/20918822/items")
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-20918822.raw"))
     stub_request(:get, "https://s3.amazonaws.com/nypl-core-objects-mapping-production/by_catalog_item_type.json")
       .to_return(status: 200, body: File.read('./spec/fixtures/by_catalog_item_type.json')) 
@@ -47,7 +47,7 @@ describe BibHandler  do
     stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
       .with(body: { fieldName: 'OwningInstitutionBibId', fieldValue: '.b114071664', 'owningInstitutions': ['NYPL'] })
       .to_return(File.new('./spec/fixtures/scsb-api-items-by-bib-id-11407166.raw'))
-    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items?nyplSource=sierra-nypl&bibId=11407166")
+    stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/11407166/items")
       .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-11407166.raw"))
   end
 
@@ -110,7 +110,7 @@ describe BibHandler  do
 
     describe "#should_process?" do
       before(:each) do
-        stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items?nyplSource=sierra-nypl&bibId=fakebibid")
+        stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/fakebibid/items")
           .to_return(status: 404, body: '{"statusCode":404,"type":"exception","message":"No records found","error":[],"debugInfo":[]}')
       end
 
@@ -122,7 +122,7 @@ describe BibHandler  do
 
   describe "#process" do
     before(:each) do
-      stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}items?nyplSource=sierra-nypl&bibId=19822713")
+      stub_request(:get, "#{ENV['PLATFORM_API_BASE_URL']}bibs/sierra-nypl/19822713/items")
         .to_return(File.new("./spec/fixtures/platform-api-items-by-bib-19822713.raw"))
       stub_request(:post, "#{Base64.strict_decode64 ENV['SCSB_API_BASE_URL']}/searchService/search")
         .with(body: { fieldName: 'OwningInstitutionBibId', fieldValue: '.b198227139', 'owningInstitutions': ['NYPL'] })


### PR DESCRIPTION
Swapping out the legacy Item Type / location check for the simpler 910|a check. We're seeing slowness in production item-by-bib-id queries, and this app is one offender. It should be determining is-research by the 910|a flag anyway. Also deprecating the mixed-bibs check, since there should not be any anymore.